### PR TITLE
Add the models version of tutorial to outline

### DIFF
--- a/outline
+++ b/outline
@@ -20,7 +20,18 @@ Fuse : articles/index.md
 
 	Fuse Studio : articles/fuse-studio/fuse-studio.md
 
-	Tutorial : articles/tutorial/tutorial.md
+
+	Tutorial (ES6 Models) : articles/tutorial-models/tutorial.md
+		1. Edit Hike view : articles/tutorial-models/edit-hike-view.md
+		2. Multiple hikes : articles/tutorial-models/multiple-hikes.md
+		3. Splitting up components : articles/tutorial-models/splitting-up-components.md
+		4. Navigation and routing : articles/tutorial-models/navigation-and-routing.md
+		5. Mocking our Backend : articles/tutorial-models/mock-backend.md
+		6. Tweaking the look/feel : articles/tutorial-models/look-and-feel.md
+		7. Splash screen : articles/tutorial-models/splash-screen.md
+		8. Final thoughts : articles/tutorial-models/final-thoughts.md
+
+	Tutorial (Legacy Observables API) : articles/tutorial/tutorial.md
 		1. Edit Hike view : articles/tutorial/edit-hike-view.md
 		2. Multiple hikes : articles/tutorial/multiple-hikes.md
 		3. Splitting up components : articles/tutorial/splitting-up-components.md


### PR DESCRIPTION
Also added a comment to indicate that the old tutorial should be
concidered legacy.