### PR TITLE
fix callouts

### DIFF
--- a/articles/assets/sketch-import.md
+++ b/articles/assets/sketch-import.md
@@ -1,8 +1,10 @@
 # Import assets from Sketch
 
-[callout warn]
+<blockquote class="callout-warn">
+
 This page relates to the old, soon-to-be-deprecated Sketch integration. You should probably check out the [new Sketch importer](./sketch-symbol-import.md) instead!
-[/callout]
+
+</blockquote>
 
 Sketch is a great vector design tool for Mac. If you haven't tried it, <a href="https://www.sketchapp.com">check it out</a>!.
 

--- a/articles/basics/installation-and-quickstart.md
+++ b/articles/basics/installation-and-quickstart.md
@@ -6,17 +6,23 @@ This is a step-by-step tutorial that takes you through setting up Fuse and creat
 
 The latest version of Fuse can always be downloaded from the <a target="_blank" href="https://fuse-open.github.io/downloads">downloads page</a>. Download the installer for your operating system and open it to start the installation procedure.
 
-[callout info]
+<blockquote class="callout-info">
+
 Both the Windows and macOS installers require an internet connection in order to complete.
-[/callout]
 
-[callout info]
+</blockquote>
+
+<blockquote class="callout-info">
+
 __Windows:__ You may have to log out and in again (or simply reboot) to make sure the path for fuse is properly updated.
-[/callout]
 
-[callout info]
+</blockquote>
+
+<blockquote class="callout-info">
+
 __macOS:__ If for any reason you need to remove all of the Fuse components, you can use [this uninstall script](https://gist.github.com/Tapped/daa78c08882f33b0c7c3).
-[/callout]
+
+</blockquote>
 
 ### macOS Requirements
 
@@ -64,9 +70,11 @@ We currently provide plugins for the following text editors:
 
 To open Fuse, double click the the Fuse icon. On macOS it is located in the "Applications" folder. If you are on Windows, it can be located in the start menu.
 
-[callout info]
+<blockquote class="callout-info">
+
 You can also start Fuse by running `fuse` from terminal on macOS or command prompt on Windows.
-[/callout]
+
+</blockquote>
 
 When opening Fuse, the first thing you'll see is the dashboard:
 

--- a/articles/basics/installation/atom-plugin.md
+++ b/articles/basics/installation/atom-plugin.md
@@ -1,6 +1,10 @@
 # Atom plugin installation
 
-> *Note:* We also provide a [plugin for Sublime Text 3](sublime-plugin.md) and [Visual Studo Code](visual-studio-code-plugin.md).
+<blockquote class="callout-info">
+
+*Note:* We also provide a [plugin for Sublime Text 3](sublime-plugin.md) and [Visual Studo Code](visual-studio-code-plugin.md).
+
+</blockquote>
 
 Make sure you've installed [Atom](https://atom.io/) first.
 

--- a/articles/basics/installation/sublime-plugin.md
+++ b/articles/basics/installation/sublime-plugin.md
@@ -1,6 +1,10 @@
 # Sublime Text 3 plugin installation
 
-> *Note:* We also provide a [plugin for Atom](atom-plugin.md) and [Visual Studo Code](visual-studio-code-plugin.md).
+<blockquote class="callout-info">
+
+*Note:* We also provide a [plugin for Atom](atom-plugin.md) and [Visual Studo Code](visual-studio-code-plugin.md).
+
+</blockquote>
 
 The Sublime plugin can be installed via the Fuse main menu or the command line.
 

--- a/articles/basics/installation/visual-studio-code-plugin.md
+++ b/articles/basics/installation/visual-studio-code-plugin.md
@@ -1,8 +1,10 @@
 # Visual Studio Code plugin installation
 
-[callout info]
+<blockquote class="callout-info">
+
 We also provide a [plugin for Atom](atom-plugin.md) and [Sublime Text 3](sublime-plugin.md).
-[/callout]
+
+</blockquote>
 
 The Visual Studio Code plugin can be installed directly from the extensions tab:
 

--- a/articles/basics/introduction-to-fuse.md
+++ b/articles/basics/introduction-to-fuse.md
@@ -4,9 +4,11 @@ This module will provide you with an introduction to the fundamentals of Fuse an
 
 The goal of this module is to give you a good understanding of what makes up a Fuse app, and to gain some practical knowledge in the process.
 
-[callout info]
+<blockquote class="callout-info">
+
 We will also cover how JavaScript fits in with Fuse, so some experience with JavaScript will be helpful in that section.
-[/callout]
+
+</blockquote>
 
 ## New project
 
@@ -28,9 +30,11 @@ Every Fuse app consists of at least two files:
 
 When we start the Fuse preview, it looks for a `.unoproj` file in the folder we're in. As long as this file exists, and we have a `.ux` file with an `App` tag (we'll cover UX markup next), we have a valid Fuse project.
 
-[callout info]
+<blockquote class="callout-info">
+
 Why is it called .unoproj you might wonder? Fuse is built on top of a programming language called Uno. This means that when Fuse compiles your code, it is actually compiling an Uno project. Knowledge about Uno is __not required__ in order to use Fuse, but for anyone who wants to dig deeper into the Fuse technology stack, more information can be found [here](articles:native-interop/native-interop).
-[/callout]
+
+</blockquote>
 
 #### UX files
 
@@ -38,9 +42,11 @@ All UX file names end with the`.ux` file extension. UX is a markup language base
 
 Our chosen project template gives us only one UX file to start with, called `MainView.ux`. To start building your app, open this file in your text editor of choice. You'll notice the file only contains two lines of code; a pair of opening and closing `App` tags.
 
-[callout info]
+<blockquote class="callout-info">
+
 UX markup is explained in detail in the next section.
-[/callout]
+
+</blockquote>
 
 ```xml
 <App>
@@ -61,9 +67,11 @@ If you paste the following code into your MainView.ux file and save it, you'll n
 
 As mentioned in the previous section, UX is the way we do most of our work in Fuse. It is where we define everything visual, as well as animations and navigation. In this section we'll introduce the basics of UX markup.
 
-[callout info]
+<blockquote class="callout-info">
+
 If you're already familiar with XML, feel free to skip forward to the next sub chapter. The terminology is a bit different from regular XML though so it may be worth a look.
-[/callout]
+
+</blockquote>
 
 ### What is UX for?
 
@@ -107,9 +115,11 @@ This is an _object_ that doesn't contain any other _objects_. When you see a tag
 
 Here we see that the `<Something>` tag doesn't end in `/>` so it needs to be closed. That's why the second tag starts with `</`. It is saying that this is 'closing tag' for a `Something` tag above.
 
-[callout info]
+<blockquote class="callout-info">
+
 Remember that even though example number two has 2 tags it is still one _object_. It's just one that can contain other _objects_ as well.
-[/callout]
+
+</blockquote>
 
 #### Using this knowledge
 
@@ -209,11 +219,13 @@ And now we can use it just like any other object that came with Fuse!
 <TextRectangle />
 ```
 
-[callout info]
+<blockquote class="callout-info">
+
 *Top tips:*
 - You may be wondering if the objects we have already seen (`StackPanel` & `Text`) have classes too, and the answer is yes. The Objects you make are just as powerful as the ones that come with the product which is pretty cool.
 - Even though `ux:Class` looks like a `Property` it is not one. If you see something that looks like a `Property` but which start with `ux:`, then it has special behavior. These special behaviors are explained in the documentation so don't worry about trying to memorize them all straight away.
-[/callout]
+
+</blockquote>
 
 ## Introduction to Layout
 
@@ -260,9 +272,11 @@ The following figure shows how objects respond to a handful of the alignment opt
 
 Now it's time to learn about some layout types and how they can be combined to create almost any app layout you can think of. You'll be introduced to three layout types: `StackPanel`, `DockPanel` and `Grid`. Note however that these aren't the only layout types in Fuse. They are however by far the most commonly used ones, and cover most of the use-cases you'll run into. You'll see more of them listed in the outline of [the docs](https://fuse-open.github.io/docs).
 
-[callout info]
+<blockquote class="callout-info">
+
 The various panels we introduce here are actually just normal panels with an associated `Layout` type. What we mean by this is that a `StackPanel` is actually just a `Panel` with a `StackLayout` attached to it. Some of the available layout types do not have these `Panel` wrappers, and so you have to add them to a normal `Panel` yourself in order to use them.
-[/callout]
+
+</blockquote>
 
 Here is an example showing how you can use the `ColumnLayout` layout:
 
@@ -461,9 +475,11 @@ observableValue.value = 40;
 
 if we data-bind to this variable, the UI will automatically update whenever we make changes to it.
 
-[callout info]
+<blockquote class="callout-info">
+
 We do __not__ use the `new` keyword when creating Observable values.
-[/callout]
+
+</blockquote>
 
 #### List observables
 
@@ -621,9 +637,11 @@ uno test ProjectName.unoproj
 
 If a test throws an error, it will be regarded as failing. If nothing is thrown, the test passes. Pretty simple! Check out the [ux:Test documentation](articles:testing/testing.md) for more details.
 
-[callout info]
+<blockquote class="callout-info">
+
 The current implementation of unit tests in Fuse is quite rudimentary. You can expect the testing API to be expanded upon in the future.
-[/callout]
+
+</blockquote>
 
 ## Animation basics
 

--- a/articles/declarative-animation.md
+++ b/articles/declarative-animation.md
@@ -160,9 +160,11 @@ The easiest way to customize the animation of pages entering and exiting a `Page
 </Page>
 ```
 
-[callout info]
+<blockquote class="callout-info">
+
 Since the `PageControl` already defines how to animate pages as the user swipes, we need to disable this if we want to add our own. We do this by setting the `Transition` property of the `Page` to `None`.
-[/callout]
+
+</blockquote>
 
 The `EnteringAnimation` and `ExitingAnimation` can be a source of confusion for people who first encounter them, but we'll try to explain them here:
 

--- a/articles/fusejs-beta/fusejs.md
+++ b/articles/fusejs-beta/fusejs.md
@@ -1,9 +1,11 @@
 
 # FuseJS
 
-[callout warn]
+<blockquote class="callout-warn">
+
 Although included in the most recent public Fuse release, the features outlined in this document are still considered experimental and not yet ready for production use. That being said, we encourage you to try it out for yourself. Feedback will always be welcome!
-[/callout]
+
+</blockquote>
 
 FuseJS allows you to write your Fuse app logic in minimalistic, modern, testable and scaleable ECMAScript 6.
 
@@ -411,9 +413,11 @@ export default class MyComponent {
 }
 ```
 
-[callout warn]
+<blockquote class="callout-warn">
+
 *Warning:* The JavaScript module you specify using the `Model` attribute will be re-evaluated every time one of the `ModelArgs` change.
-[/callout]
+
+</blockquote>
 
 #### Automatic ux:Property binding
 

--- a/articles/layout/responsive-layout.md
+++ b/articles/layout/responsive-layout.md
@@ -76,9 +76,11 @@ With the **available space** concept settled firmly, let's move on and throw `Al
 
 In this case, the nested red `Panel` with `Alignment="Top"` set will take up only 16pt vertically, and be aligned to the top of the yellow `Panel`. When we assign an `Alignment` to an element, it tries to stick to the particular side of its parent and take up as little space in the respective direction as possible. The red `Panel` still stretches to fill the full width of the available space since there are no horizontal constraints set on it.
 
-[callout info]
+<blockquote class="callout-info">
+
 At this point you might wonder what the difference between "docking" something in a `DockPanel` and aligning something is. Although the two have similar effects, __the most important difference is that aligning something does not subdivide its parents available space.__ What we mean by this is that the red `Panel` in the previous example does not "spend" its parent available space (as was done by the blue and green panels), it is instead just a way of declaring where panel should appear in the case where it is smaller (or bigger) than its parent in one or more dimensions.
-[/callout]
+
+</blockquote>
 
 If we remove the explicit `Height` on the red `Panel` and add some child elements with non-zero dimensions inside of it, the children will push the parent dimensions to accommodate the tallest child, the 200pt high maroon `Panel` in this case:
 

--- a/articles/structuring-app-resources.md
+++ b/articles/structuring-app-resources.md
@@ -66,9 +66,11 @@ In the above example we've defined the same color, but as a dynamic resource ins
 We have wrapped the `Rectangle` and `float4` resource in a `Panel` to illustrate that the resource has to be either a sibling of the `Rectangle`, or belong to one of its ancestors in order to be visible. Since we put it on the `Panel` it is available to the panels descendants, or any of its descendants.
 You might also have noticed that we needed to use a special _binding syntax_ in order to access this resource: `{Resource AppBackground}`. Since the resource might change while the app is running, we need to create a binding here so that our `Rectangle` is notified whenever that occurs. 
 
-[callout info]
+<blockquote class="callout-info">
+
 The `{Resource <key>}` binding also works for static resources defined using `ux:Global`. It will first look for a dynamic resource defined by `ux:Key`, but if none is present, it will pick the static one by the same name instead.
-[/callout]
+
+</blockquote>
 
 ## Color palettes
 
@@ -133,9 +135,11 @@ Since `MyTheme` inherits from the `WhileTrue` trigger, it can easily be turned o
 </App>
 ```
 
-[callout info]
+<blockquote class="callout-info">
+
 Note that we here have also defined a `ux:Global` for `MyApp.PrimaryColor`. This is to make sure our app has a fallback value for the case when no theme has been specified.
-[/callout]
+
+</blockquote>
 
 
 ## Fonts and text styles

--- a/articles/tutorial-models/mock-backend.md
+++ b/articles/tutorial-models/mock-backend.md
@@ -113,9 +113,11 @@ We also need to make sure we update the path to our model in `MainView.ux`, sinc
 <App Model="Models/App">
 ```
 
-[callout info]
+<blockquote class="callout-info">
+
 After moving the model class like we just did, you might need to __rebuild__ the project in order for Fuse to pick up the change. This can be done from the menu by going to Preview->Rebuild.
-[/callout]
+
+</blockquote>
 
 Now we're ready to start implementing our mock backend. As it turns out, our `Models/App.js` file already contains all the data we'll need to present. Lets start our mock backend implementation by simply moving the `hikes` array to our newly created `Services/MockBackend.js` file. But instead of assigning it to `this.hikes`, lets make it a constant and a part of the files root scope (notice the `const hikes` part):
 

--- a/articles/tutorial-models/navigation-and-routing.md
+++ b/articles/tutorial-models/navigation-and-routing.md
@@ -40,9 +40,11 @@ Now, because the @Navigator expects _templates_ instead of instances for its chi
 </App>
 ```
 
-[callout info]
+<blockquote class="callout-info">
+
 By convention, we name the templates the same as the class names when used in a navigation context. _Why_, will become apparent in the next section.
-[/callout]
+
+</blockquote>
 
 Basically, what each of these attributes says is that for a given _key_ (`HomePage` and `EditHikePage` in this case), we want the @Navigator to instantiate the associated class. So, if the @Navigator is asked to navigate to `HomePage`, it will instantiate a `HomePage` instance (if it hasn't already) and navigate there. Similarly, when asked to navigate to `EditHikePage`, it will instantiate an `EditHikePage` instance (if it hasn't already) and navigate to that instead. We can add any amount of templates we want, given that each of the keys is _unique_ (if they weren't, the @Navigator wouldn't know which template to use for a given key).
 

--- a/articles/tutorial-models/splitting-up-components.md
+++ b/articles/tutorial-models/splitting-up-components.md
@@ -53,9 +53,11 @@ As for the second question, `ux:Class` means that instead of creating an _instan
 
 But what does _extend_ mean in this context? It simply means that we're going to make our own class that is basically the same as a given class, but we'll add a few things of our own. In our case, we still want to end up with a @Page, but we want some extra stuff on it as well (the stuff that's specific to our view). So, we'll say `<Page ux:Class="EditHikePage" />`, which means we're going to create our own class called `EditHikePage` that extends the @Page class. Then, whenever we want to use this class (create an instance), instead of saying `<Page />` and putting all of our custom stuff inside it, we can simply say `<EditHikePage />`.
 
-[callout info]
+<blockquote class="callout-info">
+
 You can find out more about classes in our [Creating Components](https://fuse-open.github.io/docs/basics/creating-components) documentation.
-[/callout]
+
+</blockquote>
 
 Now that we've understood the basic contents of this file, it's time to migrate the code we want in our view over from `MainView.ux`. If we take a look at that file, we'll see something like this:
 

--- a/assets/site.css
+++ b/assets/site.css
@@ -327,3 +327,58 @@ h6.anchor-header .anchor-header-link {
 .returns p {
     margin-bottom: 0;
 }
+
+
+/*
+ * Block quote styling for callouts
+ */
+blockquote {
+    background-color: #d7ffe4;
+    padding: 1em;
+    border-left-style: solid;
+    border-left-width: 15px;
+    border-right-style: solid;
+    border-right-width: 2px;
+    border-left-color: #bffbd3;
+    border-right-color: #bffbd3;
+}
+
+blockquote p:last-child {
+    margin-bottom: 0;
+}
+
+blockquote.callout-warn {
+    color: #856404;
+    background-color: #fff3cd;
+    border-color: #ffeeba;
+}
+
+blockquote.callout-success {
+    color: #155724;
+    background-color: #d4edda;
+    border-color: #c3e6cb;
+}
+
+blockquote.callout-danger {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-color: #f5c6cb;
+}
+
+blockquote.callout-info {
+    color: #004085;
+    background-color: #cce5ff;
+    border-color: #b8daff;
+}
+
+blockquote.callout-light {
+    color: #818182;
+    background-color: #fefefe;
+    border-color: #fdfdfe;
+}
+
+blockquote.callout-dark {
+    color: #1b1e21;
+    background-color: #d6d8d9;
+    border-color: #c6c8ca;
+}


### PR DESCRIPTION
This makes the callouts actually work, by simply using inline html and
css.

There's a few unused callout types in here as well, for future use.

This was factored out of #15, and redone to avoid dependency on client-side scripting.