### PR TITLE
Stable PNGs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ script:
   - dotnet run -p generator/src/generator.csproj -- . "https://fuseopen.com/docs/" _site
   - ./copy-assets.bash _site
   - find _site/media -type f \( -iname "*.png" -or -iname "*.jpg" \) -exec mogrify -strip -resize 450x450\> {} \;
-  - find _site/media -type f -iname "*.png" -exec pngquant {} \;
+  - find _site/media -type f -iname "*.png" -exec pngquant {} \; -exec optipng -silent {} \;
   - touch _site/.nojekyll
 
 addons:
@@ -14,6 +14,7 @@ addons:
     packages:
       - imagemagick
       - pngquant
+      - optipng
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ dotnet: 2.1.102
 script:
   - dotnet run -p generator/src/generator.csproj -- . "https://fuseopen.com/docs/" _site
   - ./copy-assets.bash _site
-  - find _site/media -type f \( -iname "*.png" -or -iname "*.jpg" \) -exec mogrify -resize 450x450\> {} \;
+  - find _site/media -type f \( -iname "*.png" -or -iname "*.jpg" \) -exec mogrify -strip -resize 450x450\> {} \;
   - find _site/media -type f -iname "*.png" -exec pngquant {} \;
   - touch _site/.nojekyll
 


### PR DESCRIPTION
Every time we deploy the docs, all the PNGs end up being different than last time. This seems to be due to some unneeded metadata. So let's strip all of that.

While we're at it, shrink things a bit more by using optipng as well.