### PR TITLE
README: document how to run the site locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@
 This is the source code for the documentation for Fuse, as hosted [here](https://fuse-open.github.io/docs).
 
 The documentation is hosted on GitHub Pages, from the [gh-pages branch](https://github.com/fuse-open/docs/tree/gh-pages). This branch gets automatically updated by a Travis CI build-step.
+
+## Running locally
+
+1. Run `dotnet run -p generator/src/generator.csproj -- . "http://localhost:8000/" _site` to build the HTML files.
+2. Run `./copy-assets.bash _site` to copy assets into the target directory.
+3. Run `find _site/media -type f \( -iname "*.png" -or -iname "*.jpg" \) -exec mogrify -strip -resize 450x450\> {} \;` to resize images to the appropriate sizes.
+4. Run `python3 -m http.server 8000 --directory _site/` (or whatever your favorite static http server is) to serve the website at port 8000.
+5. Open `http://localhost/:8000` in your web browser to view the result.


### PR DESCRIPTION
During development, it's useful to be able to run the site locally. This documents how to do this.