### PR TITLE
Sidebar tweaks

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -21,14 +21,14 @@
 
     <div class="container-fluid">
       <div class="row">
-        <div class="col-12 col-lg-2 order-2 order-lg-1 bg-light sidebar">
+        <div class="col-12 col-md-3 col-xl-2 order-2 order-md-1 bg-light sidebar">
           <form id="search">
             <input type="search" class="form-control" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off">
           </form>
 
           ##NAVIGATION##
         </div>
-        <div role="main" class="col-12 col-lg-10 ml-sm-auto order-1 order-lg-2 px-4 main-content">
+        <div role="main" class="col-12 col-md-9 col-xl-10 order-1 order-md-2 px-4 main-content">
           ##BODY##
         </div>
       </div>

--- a/layout.html
+++ b/layout.html
@@ -15,18 +15,17 @@
 
   <body>
 
-    <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap p-0">
-      <a class="navbar-brand col-sm-3 col-md-2 mr-0" href="##BASE_URL##">Fuse Open Documentation</a>
-      <div class="search d-none d-lg-block w-100">
-        <form>
-          <input type="search" class="form-control" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off">
-        </form>
-      </div>
+    <nav class="navbar navbar-dark sticky-top bg-dark flex-md-nowrap">
+      <a class="navbar-brand" href="##BASE_URL##">Fuse Open Documentation</a>
     </nav>
 
     <div class="container-fluid">
       <div class="row">
         <div class="col-12 col-lg-2 order-2 order-lg-1 bg-light sidebar">
+          <form id="search">
+            <input type="search" class="form-control" id="search-input" placeholder="Search..." aria-label="Search for..." autocomplete="off">
+          </form>
+
           ##NAVIGATION##
         </div>
         <div role="main" class="col-12 col-lg-10 ml-sm-auto order-1 order-lg-2 px-4 main-content">

--- a/layout.html
+++ b/layout.html
@@ -7,7 +7,7 @@
     <meta name="author" content="">
     <title>##TITLE##</title>
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/css/bootstrap.min.css" integrity="sha384-Smlep5jCw/wG7hdkwQ/Z5nLIefveQRIY9nfy6xoR1uRYBtpZgI6339F5dgvm/e9B" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <link rel="stylesheet" href="##BASE_URL##prism.css">
     <link rel="stylesheet" href="##BASE_URL##site.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
@@ -35,8 +35,8 @@
     </div>
 
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.2/js/bootstrap.min.js" integrity="sha384-o+RDsa0aLu++PJvFqy8fFScvbHFLtbvScb8AjopnFD+iEQ7wo/CG0xlczd+2O/em" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     <script type="text/javascript" src="##BASE_URL##prism.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
     <script type="text/javascript" src="##BASE_URL##site.js"></script>

--- a/layout.html
+++ b/layout.html
@@ -24,12 +24,10 @@
       </div>
     </nav>
 
-    <div class="container-fluid main-content-wrapper">
+    <div class="container-fluid">
       <div class="row">
         <div class="col-12 col-lg-2 order-2 order-lg-1 bg-light sidebar">
-          <div class="sidebar-sticky">
-            ##NAVIGATION##
-          </div>
+          ##NAVIGATION##
         </div>
         <div role="main" class="col-12 col-lg-10 ml-sm-auto order-1 order-lg-2 px-4 main-content">
           ##BODY##

--- a/static/site.css
+++ b/static/site.css
@@ -59,16 +59,8 @@ a:hover {
  * Algolia DocSearch styling
  */
 
-.search form > span {
+form#search > span {
     width: 100%;
-}
-
-.search input#search-input {
-    color: #fff !important;
-    padding: 0.75rem 1rem !important;
-    background: rgba(255, 255, 255, 0.1) !important;
-    border: 1px solid rgba(255, 255, 255, 0.1) !important;
-    text-indent: 0 !important;
 }
 
 


### PR DESCRIPTION
This PR cleans up the CSS and design a bit. Here's the bottom-line:
- The search-bar is put in the sidebar. This makes the search-field a bit easier to discover, and removes the need to hack around with the padding.
- The sidebar is made a bit wider in narrow layouts, so things gets a bit more readable.
- Due to the removal of the padding-hacks, the navbar height is now the same as on our examples-site, even in narrow layouts (like on mobile).
- Bootstrap has been upgraded to the latest and greatest.