### PR TITLE
Drop references to 'uno install'

### DIFF
--- a/articles/alive/alive.md
+++ b/articles/alive/alive.md
@@ -6,13 +6,7 @@ Alive is a suite of included UX components that demonstrate advanced UX capabili
 
 ## Getting started
 
-To include Alive in our project, we'll begin by installing the necessary dependencies.
-Open up a command line shell (Terminal on macOS, `cmd` on Windows) and run the following commands:
-
-	uno install Fuse.Charting
-	uno install Fuse.UXKits.Alive
-
-Then, we need to add a package reference to `Fuse.UXKits.Alive` and `Fuse.Charting` in our `.unoproj`.
+To include Alive in our project, we need to add a package reference to `Fuse.UXKits.Alive` and `Fuse.Charting` in our `.unoproj`.
 It should look something like the following.
 
 ```json

--- a/articles/charting/charting.md
+++ b/articles/charting/charting.md
@@ -4,12 +4,7 @@
 
 ## Setting it up
 
-To include Fuse.Charting in our project, we'll begin by installing the necessary dependencies.
-Open up a command line shell (Terminal on macOS, `cmd` on Windows) and run the following command:
-
-	uno install Fuse.Charting
-
-Then, we need to add a package reference to `Fuse.Charting` in our `.unoproj`.
+To include Fuse.Charting in our project, we need to add a package reference to `Fuse.Charting` in our `.unoproj`.
 It should look something like the following.
 
 ```json

--- a/articles/xcode-and-android-studio-integration/tutorial.md
+++ b/articles/xcode-and-android-studio-integration/tutorial.md
@@ -2,13 +2,7 @@
 
 The `Fuse.Views` package allows you to take any UX UI component and export them as a native Library for iOS and Android. In this tutorial we will step by step look at how this is done.
 
-## Step 0: Installing dependencies
-
-To integrate with Xcode and Android Studio make sure you have installed the Fuse.Views package using the following command in either terminal (on macOS) or cmd (on Windows):
-
-```sh
-uno install Fuse.Views
-```
+## Step 0: Setting up dependencies
 
 In your `.unoproj`, add a package reference to `Fuse.Views`.
 It should look something like the following.


### PR DESCRIPTION
The mentioned packages are now part of Fuselibs (since open sourcing last year) and can no longer be installed using `uno install`.