### PR TITLE
Recommend 'uno build'

### DIFF
--- a/articles/basics/faq.md
+++ b/articles/basics/faq.md
@@ -163,7 +163,7 @@ When previewing your app, the "Oops! Something went wrong here" screen appears.
 
 If the console output contains `GL_VERSION: 1.1.0` and `GL_RENDERER: GDI Generic` the problem is most likely missing / outdated OpenGL drivers. Upgrade to the most recent drivers for your graphics adapter and try again.
 
-This problem can also be triggered by driver issues under Windows 10 specific to the Intel HD Graphics 2000 / 3000 / 4000 graphics adapters. In this case you will not be able to do local preview with instant updates, but we can still test your app on the PC by doing a regular build: `fuse build -t=dotnetexe --run`
+This problem can also be triggered by driver issues under Windows 10 specific to the Intel HD Graphics 2000 / 3000 / 4000 graphics adapters. In this case you will not be able to do local preview with instant updates, but we can still test your app on the PC by doing a regular build: `uno build --run`
 
 We can of course also still use [preview on Android and iOS devices](preview-and-export.md).
 
@@ -180,7 +180,7 @@ The more information we have on an issue, the easier it is for us to solve it. H
 5. See if your issue is triggered both in preview and when exporting a build:
     - Local preview - run `fuse preview`
 	- Device preview - run `fuse preview -tios` or `fuse preview -tandroid`
-	- Export build - run `fuse build -tios` or `fuse build -tandroid`
+	- Export build - run `uno build ios` or `uno build android`
 6. A link to a minimal reproduction project and instructions on how to trigger the bug (be specific).
     - If the repro case is quite small, you can paste your code in the issue description.
     - Try to make the project as small as possible; only include the code that is needed to make the issue manifest.

--- a/articles/basics/preview-and-export.md
+++ b/articles/basics/preview-and-export.md
@@ -107,7 +107,7 @@ The simplest way to export is to use the "Export" menu in Fuse. However, the com
 In the project root, run the following command in your shell:
 
 ```sh
-fuse build --target=Android --run
+uno build android --run
 ```
 
 This will deploy and start the project on your connected Android device.
@@ -115,7 +115,7 @@ This will deploy and start the project on your connected Android device.
 To make a **release build**, run:
 
 ```sh
-fuse build --target=Android --configuration=Release
+uno build android --configuration=Release
 ```
 
 *Note:* to export your app to the Google Play Store, you need to [sign it first](../preview-and-export/signing.md).
@@ -125,15 +125,15 @@ fuse build --target=Android --configuration=Release
 In the project root, run the following command in your shell:
 
 ```sh
-fuse build --target=iOS --run
+uno build ios --run
 ```
 
-If you instead want to open the generated project in Xcode, run `fuse build --target=iOS -adebug`
+If you instead want to open the generated project in Xcode, run `uno build ios --debug`
 
 To make a **release build**, run:
 
 ```sh
-fuse build --target=iOS --configuration=Release
+uno build ios --configuration=Release
 ```
 
 *Note:* to export your app to the App Store, you need to [sign it first](../preview-and-export/signing.md).

--- a/articles/basics/quickstart.md
+++ b/articles/basics/quickstart.md
@@ -162,7 +162,7 @@ Now that your app has at least one feature of (questionable) value, it is time t
 From the command line you do this by typing
 
 ```sh
-	fuse build --target=<iOS or Android> --run
+	uno build <ios or android> --run
 ```
 
 ### Okay, that was easy! What's next?

--- a/articles/native-interop/gradle-support.md
+++ b/articles/native-interop/gradle-support.md
@@ -9,7 +9,7 @@ You can specify the build tools version and target version for your project.
 For example:
 
 ```sh
-fuse build -t=android -r --set:SDK.BuildToolsVersion="23.0.3" --set:SDK.CompileVersion="23" --set:SDK.TargetVersion="23"`
+uno build android --run --set:SDK.BuildToolsVersion="23.0.3" --set:SDK.CompileVersion="23" --set:SDK.TargetVersion="23"`
 ```
 
 To find out which version of the tools you have installed run:
@@ -50,4 +50,4 @@ While Fuse supports `Gradle`, it does not explicitly support `Android Studio`. B
 
 The reason for this is that Android Studio is simply changing too quickly to keep up with, breaking changes are common and it is hard to test these changes with our current release cadence.
 
-We do however enable you to open builds in `Android Studio` by using the `-d` build flag, just please be aware that you may have to jump through a hoop or two to get things working if there have been updates.
+We do however enable you to open builds in `Android Studio` by using the `--debug` build flag, just please be aware that you may have to jump through a hoop or two to get things working if there have been updates.

--- a/articles/native-interop/ios-capabilities.md
+++ b/articles/native-interop/ios-capabilities.md
@@ -31,4 +31,4 @@ Entitlements are described in the Apple Documentation as:
 
 > .. a single right granted to a particular app, tool, or other executable that gives it additional permissions above and beyond what it would ordinarily have.
 
-In most cases Fuse can accurately create the correct entitlement for your chosen capability and will do so. In the other cases you can configure it as usual in Xcode. To open Xcode at the end of a build simply add `-d` command line build options, for example: `fuse build -tiOS -d`
+In most cases Fuse can accurately create the correct entitlement for your chosen capability and will do so. In the other cases you can configure it as usual in Xcode. To open Xcode at the end of a build simply add `--debug` command line build options, for example: `uno build ios --debug`

--- a/articles/preview-and-export/preview-details.md
+++ b/articles/preview-and-export/preview-details.md
@@ -1,10 +1,10 @@
 # How Fuse Preview works
 
-This article is the first in a series on how `fuse preview` works, and how it differs from `fuse build`. As a start, let's assume you're working on an app consisting of a few UX files:
+This article is the first in a series on how `fuse preview` works, and how it differs from `uno build`. As a start, let's assume you're working on an app consisting of a few UX files:
 
 ![UXFiles](../../media/preview-details-ux-files.png)
 
-When you're exporting your app, for instance with `fuse build`, those files are compiled to native code for the given platform. The result is a normal app that runs on your device, can be uploaded to the App/Play store etc. The topic of this article is however how `fuse preview` differs from that, so let's dive in!
+When you're exporting your app, for instance with `uno build`, those files are compiled to native code for the given platform. The result is a normal app that runs on your device, can be uploaded to the App/Play store etc. The topic of this article is however how `fuse preview` differs from that, so let's dive in!
 
 When you start preview of your app, for instance with `fuse preview`, some extra code is injected into your app for it to be able to pick up and display your changes while you're making them. We can of course preview your app on multiple devices at once; in this example we start two previews, one on an Android device and one locally on a Mac. We use the `fuse preview` command to start preview here, but the same thing happens when you start preview from the dashboard, or one of our editor plugins.
 

--- a/articles/preview-and-export/signing.md
+++ b/articles/preview-and-export/signing.md
@@ -30,14 +30,14 @@ keytool -genkey -v -keystore release.keystore \
 
 The program will prompt you for an alias password and a store password, which should be the same as the respective values in the project file.
 
-Note that only release builds are signed using the specified key. Debug builds are automatically signed using a debug key. To do a release build, use `uno build --target=Android --configuration=Release`.
+Note that only release builds are signed using the specified key. Debug builds are automatically signed using a debug key. To do a release build, use `uno build android --configuration=Release`.
 
 ## iOS
 
 Run the following command in your shell:
 
 ```sh
-uno build --target=iOS --configuration=Release -adebug
+uno build ios --configuration=Release --debug
 ```
 
 Then follow the regular procedure for [adding your signing certificate](https://developer.apple.com/library/ios/documentation/IDEs/Conceptual/AppDistributionGuide/ConfiguringYourApp/ConfiguringYourApp.html#//apple_ref/doc/uid/TP40012582-CH28-SW1) and [submitting your app to the App Store](https://developer.apple.com/library/ios/documentation/LanguagesUtilities/Conceptual/iTunesConnect_Guide/Chapters/SubmittingTheApp.html#//apple_ref/doc/uid/TP40011225-CH33).
@@ -64,7 +64,7 @@ Uno attempts to automatically find an Xcode Development Team ID by querying the 
 It can also be set by passing the `--set:Project.iOS.DevelopmentTeam="YOURTEAMID"` flag to `uno build`, e.g.
 
 ```sh
-uno build iOS --set:Project.iOS.DevelopmentTeam="YOURTEAMID"
+uno build ios --set:Project.iOS.DevelopmentTeam="YOURTEAMID"
 
 ```
 
@@ -78,6 +78,6 @@ The file can be created if it doesn't already exist.
 
 ### Troubleshooting
 
-Error messages such as `No matching provisioning profiles found` are usually resolved automatically just by opening the generated Uno project in Xcode once by building with `-adebug`. Also make sure that the Development Team ID has been correctly set.
+Error messages such as `No matching provisioning profiles found` are usually resolved automatically just by opening the generated Uno project in Xcode once by building with `--debug`. Also make sure that the Development Team ID has been correctly set.
 
 [This](https://developer.apple.com/library/content/documentation/IDEs/Conceptual/AppDistributionGuide/Troubleshooting/Troubleshooting.html) page contains more information about troubleshooting certificate issues.

--- a/articles/scripting/debugging.md
+++ b/articles/scripting/debugging.md
@@ -71,7 +71,7 @@ which is available both for macOS and Windows.
   to preview the project in the current working directory locally or
 
   ```sh
-  uno build --target=Android --run -DDEBUG_V8
+  uno build android --run -DDEBUG_V8
   ```
 
     to build and run on Android.

--- a/articles/xcode-and-android-studio-integration/tutorial.md
+++ b/articles/xcode-and-android-studio-integration/tutorial.md
@@ -51,8 +51,8 @@ We can then export these components by providing them as [UX Templates](articles
 Export an [Xcode Framework](https://developer.apple.com/library/content/documentation/MacOSX/Conceptual/BPFrameworks/Concepts/WhatAreFrameworks.html) or an [Android aar](https://developer.android.com/studio/projects/android-library.html) by compiling with `-DLIBRARY` set.
 
 ```sh
-uno build -t=ios -DLIBRARY
-uno build -t=android -DLIBRARY
+uno build ios -DLIBRARY
+uno build android -DLIBRARY
 ```
 
 Now you will find the Xcode framework and the Android aar under the following paths:


### PR DESCRIPTION
Recommend 'uno build' instead of 'fuse build'.

'uno' is shipped as part of Fuse SDK and 'fuse' is not, which makes
'uno' more portable and accessible to users. 'fuse' is shipped as part
of Fuse X (beta) or Fuse Studio (legacy).

Also, updates syntax on some existing examples using 'uno build'.