### PR TITLE
Options for show / hide uno props and methods

### DIFF
--- a/generator/src/Services/ApiDocumentRenderer.cs
+++ b/generator/src/Services/ApiDocumentRenderer.cs
@@ -252,6 +252,7 @@ namespace Builder.Services
             }
 
             state.AppendString($"</dl>");
+            state.AppendString($"<input class=\"advance-items\" type=\"checkbox\"><span class=\"advance-items-label\">Show Uno properties and methods</span>");
             state.AppendString($"</section>");
         }
 

--- a/static/site.css
+++ b/static/site.css
@@ -45,7 +45,7 @@ a:hover {
 }
 .main-content {
     overflow-x: hidden;
-    padding-top: 2rem;
+    padding: 2rem;
     position: static;
 }
 .main-content > p > img {
@@ -561,3 +561,10 @@ header .navbar a:link, header .navbar a:active, header .navbar a:visited, header
   text-decoration: underline;
   opacity: 1;
 }
+.advance-items {
+  margin-bottom: 2rem;
+}
+.advance-items-label {
+    font-size: 0.9rem;
+    margin-left: 0.5rem;
+  }

--- a/static/site.js
+++ b/static/site.js
@@ -39,4 +39,17 @@ $(document).ready(function() {
         $(".main-content").css({zIndex: 'unset'})
     })
 
+    // default hide advance uno props and methods
+    $('.is-advanced').css('display', 'none');
+    $('.only-advanced-items').css('display', 'none');
+
+    $(".advance-items").change(function() {
+        let show = 'none';
+        if(this.checked) {
+            show = 'block';
+        }
+        $('.is-advanced').css('display', show);
+        $('.only-advanced-items').css('display', show);
+    });
+
 });


### PR DESCRIPTION
Default we only show the UX properties and JS methods and hide the Uno properties and methods.