### PR TITLE
generator: silence .NET warnings

### DIFF
--- a/generator/src/Services/ApiJsonParser.cs
+++ b/generator/src/Services/ApiJsonParser.cs
@@ -66,7 +66,7 @@ namespace Builder.Services
                 model.SourceFileLastModifiedAt = File.GetLastWriteTimeUtc(path);
                 return NormalizeModel(model);
             }
-            catch (JsonReaderException e)
+            catch (JsonReaderException)
             {
                 _logger.LogError($"Failed to parse '{path}'");
                 throw;

--- a/generator/src/generator.csproj
+++ b/generator/src/generator.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
+  <!-- We're aware it's out of support, silence the warnings -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
       <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
This will avoid seeing various warnings from the .NET build system when
using the generator.