### PR TITLE
Fast Mode™

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ brew install imagemagick pngquant optipng
 
 > For more details about build commands see [build.sh](build.sh).
 
+### Fast Mode™
+
+When building locally using `npm start`, Fast Mode™ is enabled by
+default for the ability to test and iterate quickly. 🚀
+
+In Fast Mode™ we skip processing `api-docs/`, images, and take a few
+shortcuts -- so the resulting HTML pages are not complete, missing
+Uno/UX reference pages and related links. Most things are still fine.
+
+If you need to test a complete build, run this command instead.
+
+```shell
+npm run start-slow
+```
+
+### Other commands
+
+Type this to see all commands that are available.
+
+```shell
+npm run
+```
+
 ## Updating API docs
 
 ```shell
@@ -33,9 +56,12 @@ npm run api-docs
 ```
 
 1. Run `npm install` to install dependencies.
-2. *Optional:* Run `npm install -D fuse-sdk` to upgrade to the latest version of Fuse SDK.
-    * Or, if you wish you update API docs from another module you can do that, e.g. `@fuse-open/fuselibs` or `@fuse-open/uno`.
-    * Or, from a custom artifact, e.g. `https://ci.appveyor.com/api/buildjobs/wqgf7r6oiiwb16ff/artifacts/fuse-open-fuselibs-2.0.0.tgz`.
+2. *Optional:* Run `npm install -D fuse-sdk` to upgrade to latest versions of Fuse SDK modules.
+    * Or, if you wish specific versions you can do that. Just install the versions of `@fuse-open/fuselibs` and/or `@fuse-open/uno` that you want.
+    * Or, install a custom artifact, e.g. `https://ci.appveyor.com/api/buildjobs/wqgf7r6oiiwb16ff/artifacts/fuse-open-fuselibs-2.0.0.tgz`. You can find build artifacts on our AppVeyor pages for Uno and Fuselibs.
+    * Or, install another module for adding to our API references.
+    * Or, use `npm link` for any local modules you're working on.
+    * Run `npm outdated` to see if anything is out of date.
 3. Run `npm run api-docs` to update files in `api-docs/`, based on modules installed in step 2.
-4. Run `npm start` to build new HTML pages, presented at http://localhost:8080/.
+4. Run `npm run start-slow` to build new HTML pages, presented at http://localhost:8080/.
 5. *Optional:* Open a [Pull Request](https://github.com/fuse-open/docs/pulls) if you did something good. :)

--- a/build.sh
+++ b/build.sh
@@ -6,29 +6,44 @@ set -e
 DST="_site"
 URL="https://fuseopen.com/docs/"
 
+CP_FLAGS=""
+GEN_FLAGS=""
+FAST=0
+
 while [ $# -gt 0 ]; do
     case "$1" in
     -l|--local)
         shift
         URL="http://localhost:8080/"
         ;;
+    -f|--fast)
+        shift
+        if [[ "$OSTYPE" = msys* ]]; then
+            CP_FLAGS="--update"
+        fi
+        GEN_FLAGS="--fast"
+        FAST=1
+        ;;
     *)
-        break
+        >&2 echo "Skipping unrecognized argument $1"
+        shift
         ;;
     esac
 done
 
-echo "URL: $URL (Please wait for docs to finish building...)"
+echo -e "URL: $URL (Please wait for docs to finish building...)\n"
 
 if [ "$BUILD" != 0 ]; then
-    dotnet run -p generator/src/generator.csproj -- . "$URL" "$DST"
+    dotnet run -p generator/src/generator.csproj -- . "$URL" "$DST" $GEN_FLAGS
 fi
 
 if [ "$ASSETS" != 0 ]; then
-    cp -r media "$DST"/ &&
-    cp -r static/* "$DST"/
+    echo "Updating assets"
+    cp -r $CP_FLAGS media "$DST"/ &&
+    cp -r $CP_FLAGS static/* "$DST"/
 
-    if [[ "$OSTYPE" != msys* ]]; then
+    if [[ "$FAST" = 0 && "$OSTYPE" != msys* ]]; then
+        echo "Optimizing images"
         find "$DST"/media -type f \( -iname "*.png" -or -iname "*.jpg" \) -exec mogrify -strip -resize 850x850\> {} \;
         find "$DST"/media -type f -iname "*.png" -exec pngquant {} \; -exec optipng -silent {} \;
     fi

--- a/generator/src/BuilderSettings.cs
+++ b/generator/src/BuilderSettings.cs
@@ -8,13 +8,15 @@ namespace Builder
         public string OutputPath { get; }
         public bool GenerateReport { get; }
         public string BaseUrl { get; }
+        public bool FastMode { get; }
 
-        public BuilderSettings(string rootPath, string outputPath, bool generateReport, string baseUrl)
+        public BuilderSettings(string rootPath, string outputPath, bool generateReport, string baseUrl, bool fastMode)
         {
             RootPath = rootPath;
             OutputPath = outputPath;
             GenerateReport = generateReport;
             BaseUrl = baseUrl;
+            FastMode = fastMode;
         }
     }
 }

--- a/generator/src/Program.cs
+++ b/generator/src/Program.cs
@@ -31,13 +31,14 @@ namespace Builder
             var baseUrl = args[1];
 
             var outputPath = Path.Combine(rootPath, "generated");
-            if (args.Length == 3)
+            if (args.Length >= 3)
                 outputPath = args[2];
 
             var settings = new BuilderSettings(rootPath: rootPath,
                                                outputPath: outputPath,
                                                generateReport: args.Any(e => e == "--report"),
-                                               baseUrl: baseUrl);
+                                               baseUrl: baseUrl,
+                                               fastMode: args.Any(e => e == "--fast"));
 
             // Set up DI
             var services = new ServiceCollection().AddLogging()

--- a/generator/src/Services/ApiJsonParser.cs
+++ b/generator/src/Services/ApiJsonParser.cs
@@ -17,6 +17,7 @@ namespace Builder.Services
             ContractResolver = new CamelCasePropertyNamesContractResolver()
         };
 
+        private readonly bool _fastMode;
         private readonly string _sourcePath;
         private readonly ILogger<ApiJsonParser<T>> _logger;
 
@@ -25,10 +26,11 @@ namespace Builder.Services
 
         protected ApiJsonParser(BuilderSettings settings, ILogger<ApiJsonParser<T>> logger)
         {
+            _fastMode = settings.FastMode;
             _sourcePath = Path.Combine(settings.RootPath, "api-docs", SourceDirectoryName);
             _logger = logger;
 
-            if (!Directory.Exists(_sourcePath))
+            if (!_fastMode && !Directory.Exists(_sourcePath))
             {
                 throw new DirectoryNotFoundException($"API {SourceDirectoryDisplayName} directory '{_sourcePath}' not found");
             }
@@ -41,6 +43,12 @@ namespace Builder.Services
 
         public Task<List<T>> ReadAsync()
         {
+            if (_fastMode)
+            {
+                _logger.LogInformation("Skipping ApiJsonParser.ReadAsync() in Fast Mode");
+                return Task.FromResult(new List<T>());
+            }
+
             var sw = Stopwatch.StartNew();
             var result = new List<T>();
             

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,11 +42,30 @@
         "lodash": "^4.17.14"
       }
     },
-    "basic-auth": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
-      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -62,6 +81,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
       "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "corser": {
@@ -95,6 +120,12 @@
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
       "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
@@ -139,6 +170,20 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "glob": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -160,6 +205,15 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^2.0.0"
+      }
+    },
     "http-proxy": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
@@ -172,24 +226,50 @@
       }
     },
     "http-server": {
-      "version": "13.0.2",
-      "resolved": "https://registry.npmjs.org/http-server/-/http-server-13.0.2.tgz",
-      "integrity": "sha512-R8kvPT7qp11AMJWLZsRShvm6heIXdlR/+tL5oAWNG/86A/X+IAFX6q0F9SA2G+dR5aH/759+9PLH0V34Q6j4rg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.0.0.tgz",
+      "integrity": "sha512-XTePIXAo5x72bI8SlKFSqsg7UuSHwsOa4+RJIe56YeMUvfTvGDy7TxFkTEhfIRmM/Dnf6x29ut541ythSBZdkQ==",
       "dev": true,
       "requires": {
-        "basic-auth": "^1.0.3",
+        "basic-auth": "^2.0.1",
         "colors": "^1.4.0",
         "corser": "^2.0.1",
-        "he": "^1.1.0",
-        "http-proxy": "^1.18.0",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
         "mime": "^1.6.0",
         "minimist": "^1.2.5",
         "opener": "^1.5.1",
-        "portfinder": "^1.0.25",
+        "portfinder": "^1.0.28",
         "secure-compare": "3.0.1",
         "union": "~0.5.0",
-        "url-join": "^2.0.5"
+        "url-join": "^4.0.1"
       }
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -208,6 +288,15 @@
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.5",
@@ -236,10 +325,25 @@
       "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
       "dev": true
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
     "opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
       "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
     "portfinder": {
@@ -266,6 +370,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "secure-compare": {
@@ -295,10 +420,19 @@
       }
     },
     "url-join": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-2.0.5.tgz",
-      "integrity": "sha1-WvIvGMBSoACkjXuCxenC4v7tpyg=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
       "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.6.3"
+      }
     },
     "which": {
       "version": "2.0.2",
@@ -308,6 +442,12 @@
       "requires": {
         "isexe": "^2.0.0"
       }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "xbash": {
       "version": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -4,15 +4,20 @@
   "private": true,
   "devDependencies": {
     "fuse-sdk": "^2.0.0",
-    "http-server": "^13.0.2",
+    "http-server": "^14.0.0",
+    "rimraf": "^3.0.2",
     "xbash": "^1.6.0"
   },
   "scripts": {
     "api-docs": "uno build docs doc-export --output-dir api-docs -f",
     "build": "bash build.sh",
+    "clean": "rimraf _site",
     "deploy": "bash deploy.sh",
-    "http-server": "http-server _site",
-    "start": "bash build.sh --local && http-server _site"
+    "local": "bash build.sh --local --fast",
+    "local-slow": "bash build.sh --local",
+    "http-server": "http-server -p 8080 _site",
+    "start": "bash build.sh --local --fast && http-server -p 8080 _site",
+    "start-slow": "bash build.sh --local && http-server -p 8080 _site"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When building locally using `npm start`, Fast Mode™ is enabled by
default for the ability to test and iterate quickly. 🚀

In Fast Mode™ we skip processing `api-docs/`, images, and take a few
shortcuts -- so the resulting HTML pages are not complete, missing
Uno/UX reference pages and related links. Most things are still fine.

If you need to test a complete build, run this command instead.

```shell
npm run start-slow
```