### PR TITLE
css: Offset anchors to compensate for fixed header

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
     <link rel="stylesheet" href="##BASE_URL##prism-tomorrow.css">
-    <link rel="stylesheet" href="##BASE_URL##site.css?6">
+    <link rel="stylesheet" href="##BASE_URL##site.css?9">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
 
     <link rel="shortcut icon" href="/assets/icons/favicon.ico" />

--- a/static/site.css
+++ b/static/site.css
@@ -102,6 +102,27 @@ form#search > span {
     position: relative;
 }
 
+/** Only h{1..3}.anchor-header to avoid issues on Uno/UX reference pages */
+h1.anchor-header, h2.anchor-header, h3.anchor-header {
+    /* Offset anchor to compensate for fixed header */
+    padding-top: 120px;
+    top: -120px;
+    margin-bottom: -100px;
+    /* Avoid overlapping links in padding-area :( */
+    /* TODO: Come up with a better solution... */
+    z-index: -1;
+}
+
+/* Increase margin-top on headers */
+h1, h2, h3 {
+    margin-top: 30px;
+}
+
+/* Disable margin-top on first header */
+h1:first-child, h2:first-child, h3:first-child {
+    margin-top: 0 !important;
+}
+
 .anchor-header-link {
     font-size: 1rem;
     color: #332f2f;


### PR DESCRIPTION
This is some CSS hacking to avoid headers ending up below (z-order) our
fixed header when using anchor links or clicking links in the right-hand
sidebar.

Also adds some more margin pixels above headers in general.

We needed to add a negative z-index property in order to avoid making
links inside the resulting padding-area unclickable. The drawback is
that hovering and clicking the anchor-headers themselves don't work
anymore. However, correct positioning when using anchor links or
clicking links in the right-hand sidebar seems more important.

If someone knows a better trick than negative z-index, that would be
very interesting to hear about. :)